### PR TITLE
Set a conservative default batch size for fetching open trades

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -624,7 +624,7 @@ async function fetchOpenTrades(){
 			},
 			{
 				useMulticall: true,
-				pairBatchSize: 50,
+				pairBatchSize: 10, // This is a conservative batch size to accommodate high trade volumes and default RPC payload limits. Consider adjusting.
 			}
 		);
 


### PR DESCRIPTION
Depending on trade volume and RPC payload limits, multicall fetching will fail. I've dramatically reduced the default value to be more inclusive.

We should consider upgrading the SDK to include an option to retry with smaller batch sizes when the provided value is too large.